### PR TITLE
Optionally use datapoint tags as topic names.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/resources/kairos-kafkapush.properties
+++ b/src/main/resources/kairos-kafkapush.properties
@@ -1,12 +1,34 @@
+#
+# Required properties are uncommented, optional properties are commented out with
+# their default values shown
+#
 kairosdb.service.kafkapush=org.kairosdb.plugin.kafkapush.KafkaPushModule
 
-# server, port, and topic must be defined. sever and port are just for bootstrapping to find the rest of the cluster.
-kairosdb.kafkapush.server=localhost
-kairosdb.kafkapush.port=9092
-kairosdb.kafkapush.topic=test
+# A list of host/port pairs in the form of "host1:port1,host2:port2,..". These are used
+# for bootstrapping, so the full set of Kafka hosts is not required, but at least one
+# host:port pair is required
+kairosdb.kafkapush.servers=localhost:9092
+
+
+# The plugin will decide which Kafka topics to push to using the value of specified tag
+# in the datapoint. If the tag is not found in a given datapoint, the default topic will
+# be used. Your kafka cluster should probably be set with:auto.create.topics.enable = true
+# This is the default for many Kafka installations. topic.default is required. topic.tag
+# is optional.
+kairosdb.kafkapush.topic.default=test
+#kairosdb.kafkapush.topic.tag=
+
+
+
+# Kafka topic names must contain only: a-z,A-Z,0-9,'.', '_', and '-'. Also, Kafka
+# recommends using either dot or underscore but not both across a given Kafka instance.
+# So, when extracting the Kafka topic name, all alphanumerics and '-' characters will
+# pass through. Everything else will be replaced by the chosen character below, which
+# must be one of 'dash', 'dot' or 'underscore'. If anything but those three values is
+# given, defaults to 'underscore'
+#kariosdb.kafkapush.topic.replacechar=underscore
 
 # See http://kafka.apache.org/documentation.html#producerconfigs for explanations of the fields below
-# These are options, default values shown.
 #kairosdb.kafkapush.ack = all
 #kairosdb.kafkapush.retries = 0
 #kairosdb.kafkapush.linger = 1

--- a/src/test/java/org/kairosdb/plugin/kafkapush/KafkaPushInitialSetupTest.java
+++ b/src/test/java/org/kairosdb/plugin/kafkapush/KafkaPushInitialSetupTest.java
@@ -1,0 +1,106 @@
+package org.kairosdb.plugin.kafkapush;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class KafkaPushInitialSetupTest
+{
+    @Test(expected = IllegalArgumentException.class)
+    public void propertiesDefaultTopicMissing()
+    {
+        Properties testProps = new Properties();
+        new KafkaPushDataPointListener(testProps, new MockProducer<>(true, new StringSerializer(), new StringSerializer()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void propertiesDefaultTopicEmpty()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "");
+        new KafkaPushDataPointListener(testProps, new MockProducer<>(true, new StringSerializer(), new StringSerializer()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void propertiesDefaultTopicBlank()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "   ");
+        new KafkaPushDataPointListener(testProps, new MockProducer<>(true, new StringSerializer(), new StringSerializer()));
+    }
+
+    @Test
+    public void propertiesDefaultTopicTrimmed()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "   test");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, new MockProducer<>(true, new StringSerializer(), new StringSerializer()));
+
+        assertEquals("test", testListner.getKafkaDefaultTopic());
+    }
+
+    @Test
+    public void propertiesTopicReplaceCharMissing()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "test");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, new MockProducer<>(true, new StringSerializer(), new StringSerializer()));
+
+        assertEquals("_", testListner.getKafkaTopicReplaceChar());
+    }
+
+    @Test
+    public void propertiesTopicReplaceCharUnderscore()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "test");
+        testProps.setProperty("kairosdb.kafkapush.topic.replacechar", "underscore ");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, new MockProducer<>(true, new StringSerializer(), new StringSerializer()));
+
+        assertEquals("_", testListner.getKafkaTopicReplaceChar());
+    }
+
+    @Test
+    public void propertiesTopicReplaceCharDot()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "test");
+        testProps.setProperty("kairosdb.kafkapush.topic.replacechar", "   dot ");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, new MockProducer<>(true, new StringSerializer(), new StringSerializer()));
+
+        assertEquals(".", testListner.getKafkaTopicReplaceChar());
+    }
+
+    @Test
+    public void propertiesTopicReplaceCharDash()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "test");
+        testProps.setProperty("kairosdb.kafkapush.topic.replacechar", "   dash");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, new MockProducer<>(true, new StringSerializer(), new StringSerializer()));
+
+        assertEquals("-", testListner.getKafkaTopicReplaceChar());
+    }
+
+    @Test
+    public void propertiesTopicReplaceCharInvalid()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "test");
+        testProps.setProperty("kairosdb.kafkapush.topic.replacechar", " not_a_valid_thing  ");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, new MockProducer<>(true, new StringSerializer(), new StringSerializer()));
+
+        assertEquals("_", testListner.getKafkaTopicReplaceChar());
+    }
+}

--- a/src/test/java/org/kairosdb/plugin/kafkapush/KafkaPushTopicTest.java
+++ b/src/test/java/org/kairosdb/plugin/kafkapush/KafkaPushTopicTest.java
@@ -1,0 +1,114 @@
+package org.kairosdb.plugin.kafkapush;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.Before;
+import org.junit.Test;
+import org.kairosdb.core.datapoints.LongDataPoint;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertTrue;
+
+
+public class KafkaPushTopicTest
+{
+    private ImmutableSortedMap<String, String> testTags;
+    private long now;
+    private MockProducer<String, String> mockKafka;
+
+    @Before
+    public void setup(){
+        now = System.currentTimeMillis();
+
+        testTags = ImmutableSortedMap.<String, String>naturalOrder()
+                .put("tag_valid", "foo")
+                .put("tag_empty", "")
+                .put("tag_blank", "   ")
+                .put("tag_invalid", "#abcd^&$@ -._  ")
+                .build();
+
+        mockKafka = new MockProducer<>(true, new StringSerializer(), new StringSerializer());
+    }
+
+    @Test
+    public void validTopicTagInMessage()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "default");
+        testProps.setProperty("kairosdb.kafkapush.topic.replacechar", "dot");
+        testProps.setProperty("kairosdb.kafkapush.topic.tag", "tag_valid");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, mockKafka);
+
+        testListner.dataPoint("metric.name",testTags, new LongDataPoint(now, 1));
+        assertTrue(checkMessageTopic("foo"));
+    }
+
+    @Test
+    public void emptyTopicTagInMessage()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "default");
+        testProps.setProperty("kairosdb.kafkapush.topic.replacechar", "dot");
+        testProps.setProperty("kairosdb.kafkapush.topic.tag", "tag_empty");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, mockKafka);
+
+        testListner.dataPoint("metric.name",testTags, new LongDataPoint(now, 1));
+        assertTrue(checkMessageTopic("default"));
+    }
+
+    @Test
+    public void blankTopicTagInMessage()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "default");
+        testProps.setProperty("kairosdb.kafkapush.topic.replacechar", "dot");
+        testProps.setProperty("kairosdb.kafkapush.topic.tag", "tag_blank");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, mockKafka);
+
+        testListner.dataPoint("metric.name",testTags, new LongDataPoint(now, 1));
+        assertTrue(checkMessageTopic("default"));
+    }
+
+    @Test
+    public void replaceCharsInTopicTag()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", "default");
+        testProps.setProperty("kairosdb.kafkapush.topic.replacechar", "dot");
+        testProps.setProperty("kairosdb.kafkapush.topic.tag", "tag_invalid");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, mockKafka);
+
+        testListner.dataPoint("metric.name",testTags, new LongDataPoint(now, 1));
+        assertTrue(checkMessageTopic(".abcd.....-.."));
+    }
+
+    @Test
+    public void replaceCharsInDefaultTopic()
+    {
+        Properties testProps = new Properties();
+        testProps.setProperty("kairosdb.kafkapush.topic.default", " Test_4.Topic!");
+        testProps.setProperty("kairosdb.kafkapush.topic.replacechar", "dash");
+        testProps.setProperty("kairosdb.kafkapush.topic.tag", "tag_missing");
+        KafkaPushDataPointListener testListner =
+                new KafkaPushDataPointListener(testProps, mockKafka);
+
+        testListner.dataPoint("metric.name",testTags, new LongDataPoint(now, 1));
+        assertTrue(checkMessageTopic("Test-4-Topic-"));
+    }
+
+    private boolean checkMessageTopic(String testTopic)
+    {
+        List<ProducerRecord<String, String>> results = mockKafka.history();
+        mockKafka.clear();
+        return results.size() == 1 &&
+                testTopic.equals(results.get(0).topic());
+    }
+}


### PR DESCRIPTION
- Allow the use of a specific tag as the Kafka topic per message,
falling back to the default topic if the result is blank for any
reason

- Normalize the result of the tag or default to fit within the
rules for Kafka topic names

- Unit tests!